### PR TITLE
Domain names auction #53

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ add_subdirectory(eosio.msig)
 add_subdirectory(eosio.wrap)
 add_subdirectory(eosio.system)
 add_subdirectory(eosio.token)
+add_subdirectory(cyber.domain)
 
 if (APPLE)
    set(OPENSSL_ROOT "/usr/local/opt/openssl")

--- a/cyber.domain/CMakeLists.txt
+++ b/cyber.domain/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_contract_with_abi(cyber.domain cyber.domain.abi ${CMAKE_CURRENT_SOURCE_DIR}/cyber.domain.cpp)
+target_include_directories(cyber.domain.wasm
+   PUBLIC
+   ${CMAKE_CURRENT_SOURCE_DIR}/../eosio.system/include
+   ${CMAKE_CURRENT_SOURCE_DIR}/../eosio.token/include)
+
+set_target_properties(cyber.domain.wasm
+   PROPERTIES
+   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
+install (TARGETS eosio.system.wasm DESTINATION ${CMAKE_INSTALL_PREFIX}/cyber.domain/)
+#install (FILES ${CMAKE_CURRENT_BINARY_DIR}/cyber.domain.abi DESTINATION ${CMAKE_INSTALL_PREFIX}/cyber.domain/)

--- a/cyber.domain/cyber.domain.abi
+++ b/cyber.domain/cyber.domain.abi
@@ -1,0 +1,131 @@
+{
+    "version": "cyberway::abi/1.0",
+    "types": [
+        {"new_type_name": "domain_name", "type": "string"}
+    ]
+    "structs": [
+        {
+            "name": "newdomain",
+            "base": "",
+            "fields": [
+                {"type": "name",        "name": "creator"},
+                {"type": "domain_name", "name": "name"}
+            ]
+        },{
+            "name": "biddomain",
+            "base": "",
+            "fields": [
+                {"type": "name",        "name": "bidder"},
+                {"type": "domain_name", "name": "name"},
+                {"type": "asset",       "name": "bid"}
+            ]
+        },{
+            "name": "biddmrefund",
+            "base": "",
+            "fields": [
+                {"type": "name",        "name": "bidder"},
+                {"type": "domain_name", "name": "name"}
+            ]
+        },{
+            "name": "checkwin",
+            "base": "",
+            "fields": []
+        },{
+            "name": "domain_bid_state",
+            "base": "",
+            "fields": [
+                {"type": "uint64",         "name": "id"},
+                {"type": "time_point_sec", "name": "last_win"},
+                {"type": "time_point_sec", "name": "last_checkwin"}
+            ]
+        },{
+            "name": "domain_bid",
+            "base": "",
+            "fields": [
+                {"type": "uint64",          "name": "id"},
+                {"type": "domain_name",     "name": "name"},
+                {"type": "name",            "name": "high_bidder"},
+                {"type": "int64",           "name": "high_bid"},
+                {"type": "time_point_sec",  "name": "last_bid_time"}
+            ]
+        },{
+            "name": "domain_bid_refund",
+            "base": "",
+            "fields": [
+                {"type": "name",  "name": "bidder"},
+                {"type": "asset", "name": "amount"}
+            ]
+        }
+    ],
+    "types": [],
+    "actions": [
+        {
+            "name": "biddomain",
+            "type": "biddomain",
+            "ricardian_contract": ""
+        },{
+            "name": "biddmrefund",
+            "type": "biddmrefund",
+            "ricardian_contract": ""
+        },{
+            "name": "newdomain",
+            "type": "newdomain",
+            "ricardian_contract": ""
+        },{
+            "name": "checkwin",
+            "type": "checkwin",
+            "ricardian_contract": ""
+        }
+    ],
+    "tables": [
+        {
+            "name": "domainbid",
+            "type": "domain_bid",
+            "indexes": [
+                {
+                    "name": "primary",
+                    "unique": "true",
+                    "orders": [
+                        {"field": "id", "order": "asc"}
+                    ]
+                },{
+                    "name": "domain",
+                    "unique": "true",
+                    "orders": [
+                        {"field": "name", "order": "asc"}
+                    ]
+                },{
+                    "name": "highbid",
+                    "unique": "true",
+                    "orders": [
+                        {"field": "high_bid", "order": "desc"},
+                        {"field": "name", "order": "asc"}
+                    ]
+                }
+            ]
+        },{
+            "name": "dbidrefund",
+            "type": "domain_bid_refund",
+            "indexes": [{
+                "name": "primary",
+                "unique": "true",
+                "orders": [
+                    {"field": "bidder", "order": "asc"}
+                ]
+            }]
+        },{
+            "name": "dbidstate",
+            "type": "domain_bid_state",
+            "indexes": [{
+                "name": "primary",
+                "unique": "true",
+                "orders": [
+                    {"field": "id", "order": "asc"}
+                ]
+            }]
+        }
+    ],
+    "ricardian_clauses": [],
+    "variants": [],
+    "abi_extensions": []
+}

--- a/cyber.domain/cyber.domain.cpp
+++ b/cyber.domain/cyber.domain.cpp
@@ -1,0 +1,179 @@
+#include "cyber.domain.hpp"
+#include <eosio.system/eosio.system.hpp>
+#include <eosio.token/eosio.token.hpp>
+#include <eosiolib/eosio.hpp>
+#include <eosiolib/transaction.hpp>
+#include <eosiolib/dispatcher.hpp>
+
+#include "domain_validate.cpp"
+
+namespace eosiosystem {
+
+
+// constants
+const uint32_t seconds_per_hour      = 60 * 60;
+// const uint32_t seconds_per_day       = 24 * seconds_per_hour;    // declared in eosio::system header…
+const uint32_t seconds_per_year      = 365 * seconds_per_day;   // note: it's 52*7=364 in eos
+
+// config
+const uint32_t checkwin_interval = seconds_per_hour;
+const uint32_t min_time_from_last_win = seconds_per_day;
+const uint32_t min_time_from_last_bid = seconds_per_day;
+
+using namespace eosio;
+
+void validate_domain_name(const domain_name& n);
+void validate_username(const username& n);
+
+
+symbol core_symbol() {
+    // const static auto sym = system_contract::get_core_symbol();  // requires system contract, which is not ready yet
+    const static auto sym = symbol("SYS", 4);
+    return sym;
+}
+
+void domain::checkwin() {
+    require_auth(_self);
+    const int64_t now = ::now();                // int64 to prevent overflows (can only happen if something broken)
+    auto tnow = time_point_sec(now);
+
+    auto state = state_singleton(_self, _self.value);
+    bool exists = state.exists();
+    auto s = exists ? state.get() : domain_bid_state{tnow, tnow};
+    if (exists) {
+        auto diff = now - s.last_checkwin.utc_seconds;
+        eosio_assert(diff >= 0, "SYSTEM: last_checkwin is in future");  // must be impossible
+        if (diff != checkwin_interval) {
+            eosio_assert(diff > checkwin_interval, "checkwin called too early");
+            print("checkwin delayed\n");
+        }
+        if (now - s.last_win.utc_seconds > min_time_from_last_win) {
+            domain_bid_tbl bids(_self, _self.value);
+            auto idx = bids.get_index<"highbid"_n>();
+            auto highest = idx.begin();
+            if (highest != idx.end() &&
+                highest->high_bid > 0 &&
+                now - highest->last_bid_time.utc_seconds > min_time_from_last_bid
+            ) {
+                s.last_win = tnow;
+                idx.modify(highest, same_payer, [&](auto& b) {
+                    b.high_bid = -b.high_bid;
+                });
+            }
+        }
+        s.last_checkwin = tnow;
+    }
+    state.set(s, _self);
+
+    print("schedule next\n");
+    auto sender_id = s.last_checkwin.utc_seconds;
+    transaction tx;
+    tx.actions.emplace_back(action{permission_level(_self, active_permission), _self, "checkwin"_n, std::tuple<>()});
+    tx.delay_sec = checkwin_interval;
+    tx.send(sender_id, _self);
+}
+
+
+void domain::biddomain(name bidder, const domain_name& name, asset bid) {
+    require_auth(bidder);
+    validate_domain_name(name);
+    eosio_assert(!is_domain(name), "domain already exists");
+    eosio_assert(bid.symbol == core_symbol(), "asset must be system token");
+    eosio_assert(bid.amount > 0, "insufficient bid");
+
+    INLINE_ACTION_SENDER(eosio::token, transfer)(
+        token_account, {{bidder, active_permission}},
+        {bidder, names_account, bid, std::string("bid domain ") + name}
+    );
+
+    domain_bid_tbl bids(_self, _self.value);
+    print(bidder, " bid ", bid, " on ", name, "\n");
+
+    const auto set_bid = [&](auto& b) {
+        b.high_bidder = bidder;
+        b.high_bid = bid.amount;
+        b.last_bid_time = time_point_sec{::now()};
+    };
+    auto idx = bids.get_index<"domain"_n>();
+    auto current = idx.find(name);
+    if (current == idx.end()) {
+        bids.emplace(bidder, [&](auto& b) {
+            b.id = bids.available_primary_key();
+            b.domain = name;
+            set_bid(b);
+        });
+    } else {
+        eosio_assert(current->high_bid > 0, "this auction has already closed");
+        eosio_assert((bid.amount - current->high_bid)*10 >= current->high_bid, "must increase bid by 10%");
+        eosio_assert(current->high_bidder != bidder, "account is already highest bidder");
+
+        // the scope was newname.value, but we have string, so simplify.
+        // downside: refund sum can be accumulated over several domains
+        domain_bid_refund_tbl refunds(_self, _self.value);
+        auto to_refund = asset(current->high_bid, core_symbol());
+        auto itr = refunds.find(current->high_bidder.value);
+        if (itr != refunds.end()) {
+            refunds.modify(itr, same_payer, [&](auto& r) {
+                r.amount += to_refund;
+            });
+        } else {
+            refunds.emplace(bidder, [&](auto& r) {
+                r.bidder = current->high_bidder;
+                r.amount = to_refund;
+            });
+        }
+
+        transaction tx;
+        tx.actions.emplace_back(permission_level{_self, active_permission},
+            _self, "biddmrefund"_n, std::make_tuple(current->high_bidder, name)
+        );
+        tx.delay_sec = 0;
+        uint128_t deferred_id = current->high_bidder.value; // note: high 64 bits was newname.value
+        cancel_deferred(deferred_id);
+        tx.send(deferred_id, bidder);
+
+        idx.modify(current, bidder, set_bid);
+    }
+}
+
+// note: domain name is only used for transfer memo
+void domain::biddmrefund(name bidder, const domain_name& name) {
+    domain_bid_refund_tbl refunds(_self, _self.value);  // the scope was newname.value, but we have string, so simplify
+    auto itr = refunds.find(bidder.value);
+    eosio_assert(itr != refunds.end(), "refund not found");
+    INLINE_ACTION_SENDER(eosio::token, transfer)(
+        token_account, {{names_account, active_permission}, {bidder, active_permission}},
+        {names_account, bidder, asset(itr->amount), std::string("refund bid on domain ")+name}
+    );
+    refunds.erase(itr);
+}
+
+// name is already validated at this point
+void domain_native::newdomain(name creator, const domain_name& name) {
+    if (creator != _self) {
+        auto dot = name.find('.');
+        bool tld = dot == std::string::npos;    // Top Level Domain; TODO: decide what to do with SLD
+        if (tld) {
+            // auction
+            domain_bid_tbl bids(_self, _self.value);
+            auto idx = bids.get_index<"domain"_n>();
+            auto bid = idx.find(name);
+            eosio_assert(bid != idx.end(), "no active bid for domain");
+            eosio_assert(bid->high_bidder == creator, "only highest bidder can claim");
+            eosio_assert(bid->high_bid < 0, "auction for domain is not closed yet");
+            idx.erase(bid);
+        } else {
+            // only domain owner can create subdomains
+            const domain_name suffix = name.substr(dot+1, name.size()-dot-1);
+            eosio_assert(is_domain(suffix), "parent domain do not exists");
+            eosio_assert(creator == get_domain_owner(suffix), "only owner of parent domain can create subdomain");
+        }
+    }
+}
+
+} // eosiosystem
+
+
+EOSIO_DISPATCH(eosiosystem::domain,
+    (checkwin)(biddomain)(biddmrefund)(newdomain)
+)

--- a/cyber.domain/cyber.domain.hpp
+++ b/cyber.domain/cyber.domain.hpp
@@ -1,0 +1,68 @@
+#pragma once
+#include "domain_native.hpp"
+#include <eosiolib/domain.hpp>
+#include <eosiolib/asset.hpp>
+#include <eosiolib/name.hpp>
+#include <eosiolib/time.hpp>
+#include <eosiolib/singleton.hpp>
+#include <string>
+
+namespace eosiosystem {
+
+using eosio::domain_name;
+using eosio::username;
+using eosio::name;
+using eosio::asset;
+using eosio::time_point_sec;
+
+
+struct [[eosio::table, eosio::contract("cyber.domain")]] domain_bid {
+    uint64_t        id;
+    domain_name     domain;
+    name            high_bidder;
+    int64_t         high_bid = 0;   ///< negative high_bid == closed auction waiting to be claimed
+    time_point_sec  last_bid_time;
+
+    uint64_t primary_key()  const { return id; }
+    domain_name by_domain() const { return domain; }
+    int64_t by_high_bid()   const { return high_bid; }      // ordered desc, check abi
+};
+
+struct [[eosio::table, eosio::contract("cyber.domain")]] domain_bid_refund {
+    name  bidder;
+    asset amount;
+
+    uint64_t primary_key() const { return bidder.value; }
+};
+
+using domain_bid_tbl = eosio::multi_index<"domainbid"_n, domain_bid,
+    eosio::indexed_by<"domain"_n, eosio::const_mem_fun<domain_bid, domain_name, &domain_bid::by_domain>>,
+    eosio::indexed_by<"highbid"_n, eosio::const_mem_fun<domain_bid, int64_t, &domain_bid::by_high_bid>>
+>;
+using domain_bid_refund_tbl = eosio::multi_index< "dbidrefund"_n, domain_bid_refund>;
+
+struct [[eosio::table("state"), eosio::contract("cyber.domain")]] domain_bid_state {
+    time_point_sec last_win;
+    time_point_sec last_checkwin;
+
+    // explicit serialization macro is not necessary, used here only to improve compilation time
+    EOSLIB_SERIALIZE(domain_bid_state, (last_win)(last_checkwin))
+};
+using state_singleton = eosio::singleton<"dbidstate"_n, domain_bid_state>;
+
+
+class [[eosio::contract("cyber.domain")]] domain: public domain_native {
+public:
+    // TODO: move this names to system config
+    static constexpr name active_permission{"active"_n};
+    static constexpr name token_account{"eosio.token"_n};
+    static constexpr name names_account{"cyber.names"_n};
+
+    using domain_native::domain_native;
+
+    [[eosio::action]] void checkwin();
+    [[eosio::action]] void biddomain(name bidder, const domain_name& name, asset bid);
+    [[eosio::action]] void biddmrefund(name bidder, const domain_name& name);
+};
+
+} /// eosiosystem

--- a/cyber.domain/domain_native.hpp
+++ b/cyber.domain/domain_native.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <eosiolib/domain.hpp>
+#include <eosiolib/contract.hpp>
+
+namespace eosiosystem {
+
+class [[eosio::contract("cyber.domain")]] domain_native: public eosio::contract {
+public:
+    using eosio::contract::contract;
+
+    /**
+     *  Called after a new domain is created. This code enforces new domain naming conventions.
+     */
+    [[eosio::action]] void newdomain(eosio::name creator, const eosio::domain_name& name);
+};
+
+}

--- a/cyber.domain/domain_validate.cpp
+++ b/cyber.domain/domain_validate.cpp
@@ -1,0 +1,114 @@
+#include <eosiolib/domain.hpp>
+#include <string>
+#include <vector>
+
+namespace eosiosystem {
+
+using std::string;
+using std::vector;
+
+// now we have 2 validator implementations, here and in core. TODO: fix
+// 1. reuse core implementation, buut looks like it's costly to swich from wasm
+// 2. embed in cdt, looks good, but still 2 implementations
+// 3. embed in serializer/deserializer, so input guaranteed to be valid
+
+// constants
+constexpr size_t domain_max_size = 253;
+constexpr size_t domain_min_part_size = 1;
+constexpr size_t domain_max_part_size = 63;
+
+constexpr size_t username_max_size = 32;        // it's 16 in Golos
+constexpr size_t username_min_part_size = 1;    // it's 3 in Golos
+constexpr size_t username_max_part_size = 32;
+
+
+inline bool is_digit(char c) {
+    return c >= '0' && c <= '9';
+}
+inline bool is_letter(char c) {
+    return c >= 'a' && c <= 'z';
+}
+inline bool is_allowed_punct(char c) {
+    return c == '-' || c == '.';
+}
+inline bool is_valid_char(char c) {
+    return is_letter(c) || is_digit(c) || is_allowed_punct(c);
+}
+
+// TODO: optimize to use tokenizer-like processing instead of vector of strings
+vector<string> split(const string& s, char d) {
+    vector<string> r;
+    size_t pos = 0, len = s.size();
+    while (pos <= len) {
+        auto next = s.find(d, pos);
+        auto end = next != string::npos ? next : len;
+        r.emplace_back(s.substr(pos, end - pos));
+        pos = end + 1;
+    };
+    return r;
+}
+
+enum name_error {
+    valid = 0,
+    name_too_long,
+    part_too_short,
+    part_too_long,
+    bad_part_edge,
+    bad_char,
+    all_numeric
+};
+
+// name consists of 1 or more parts delimited by dots
+name_error validate_part(const string& n, size_t min_size, size_t max_size) {
+    if (n.size() < min_size) return part_too_short;
+    if (n.size() > max_size) return part_too_long;
+    if (n[0] == '-' || n.back() == '-') return bad_part_edge; // Domain labels may not start or end with a hyphen
+    // if (!std::all_of(n.begin(), n.end(), is_valid_char)) return bad_char;   // checked outside
+    return valid;
+}
+
+name_error validate_domain_name(const string& d, size_t max_size, size_t min_part, size_t max_part, bool strict_tld) {
+    if (d.size() > max_size) return name_too_long;
+    if (!std::all_of(d.begin(), d.end(), is_valid_char)) return bad_char;
+    auto parts = split(d, '.');
+    for (const auto& part: parts) {
+        auto r = validate_part(part, min_part, max_part);
+        if (r != valid) return r;
+    }
+    // Top-level domain names should not be all-numeric
+    if (strict_tld) {
+        auto tld = parts.back();
+        if (std::all_of(tld.begin(), tld.end(), is_digit)) return all_numeric;
+    }
+    return valid;
+}
+
+void validate_domain_name(const domain_name& n) {
+    auto r = validate_domain_name(n, domain_max_size, domain_min_part_size, domain_max_part_size, true);
+    static const vector<string> err = {
+        "",
+        "Domain name is too long",
+        "Domain label is too short",
+        "Domain label is too long",
+        "Domain label can't start or end with '-'",
+        "Domain name contains bad symbol",
+        "Top-level name is all-numeric"
+    };
+    eosio_assert(r == valid, err[r].c_str());
+}
+
+void validate_username(const username& n) {
+    auto r = validate_domain_name(n, username_max_size, username_min_part_size, username_max_part_size, false);
+    static const vector<string> err = {
+        "",
+        "Username is too long",
+        "Username part is too short",
+        "Username part is too long",
+        "Username part can't start or end with '-'",
+        "Username contains bad symbol"
+    };
+    eosio_assert(r == valid, err[r].c_str());
+}
+
+
+} // eosiosystem

--- a/tests/contracts.hpp.in
+++ b/tests/contracts.hpp.in
@@ -12,6 +12,8 @@ static inline std::vector<char> read_abi(const std::string& filename) {return re
 struct contracts {
    static std::vector<uint8_t> system_wasm() { return read_wasm(cyberway_contracts + "/eosio.system/eosio.system.wasm"); }
    static std::vector<char>    system_abi() { return read_abi(cyberway_contracts + "/eosio.system/eosio.system.abi"); }
+   static std::vector<uint8_t> domain_wasm() { return read_wasm(cyberway_contracts + "/cyber.domain/cyber.domain.wasm"); }
+   static std::vector<char>    domain_abi() { return read_abi(cyberway_contracts + "/cyber.domain/cyber.domain.abi"); }
    static std::vector<uint8_t> token_wasm() { return read_wasm(cyberway_contracts + "/eosio.token/eosio.token.wasm"); }
    static std::vector<char>    token_abi() { return read_abi(cyberway_contracts + "/eosio.token/eosio.token.abi"); }
    static std::vector<uint8_t> msig_wasm() { return read_wasm(cyberway_contracts + "/eosio.msig/eosio.msig.wasm"); }


### PR DESCRIPTION
Domains auction implementation based on account names auction.
Adds 4 actions:
+ `checkwin` — periodically called action which checks if there winner on any domain name. Re-schedules itself.
+ `biddomain` — allows account to bid on domain name
+ `biddmrefund` — refunds bid if greater bid set on the same domain name, called internally
+ `newdomain` — implements restrictions on creating new domain. The following ways are allowed:
    * system account can create domain names
    * owner of direct parent domain can create subdomains
    * winner of domain auction claims his domain name by creating it

Note: bidder must allow `cyber.domain` account to transfer funds reserved as bid.
Note: `cyber.domain` account must be privileged or have permissions to transfer funds from `cyber.names` account (refunds).