### PR TITLE
Base implementation of declarenames action (cyber.domain) #56

### DIFF
--- a/cyber.domain/cyber.domain.abi
+++ b/cyber.domain/cyber.domain.abi
@@ -1,7 +1,8 @@
 {
     "version": "cyberway::abi/1.0",
     "types": [
-        {"new_type_name": "domain_name", "type": "string"}
+        {"new_type_name": "domain_name", "type": "string"},
+        {"new_type_name": "username",    "type": "string"}
     ]
     "structs": [
         {
@@ -30,6 +31,20 @@
             "name": "checkwin",
             "base": "",
             "fields": []
+        },{
+            "name": "declarenames",
+            "base": "",
+            "fields": [
+                {"type": "name_info[]", "name": "domains"}
+            ]
+        },{
+            "name": "name_info",
+            "base": "",
+            "fields": [
+                {"type": "domain_name", "name": "domains"},
+                {"type": "name",        "name": "account"},
+                {"type": "username[]",  "name": "users"}
+            ]
         },{
             "name": "domain_bid_state",
             "base": "",
@@ -74,6 +89,10 @@
         },{
             "name": "checkwin",
             "type": "checkwin",
+            "ricardian_contract": ""
+        },{
+            "name": "declarenames",
+            "type": "declarenames",
             "ricardian_contract": ""
         }
     ],

--- a/cyber.domain/cyber.domain.cpp
+++ b/cyber.domain/cyber.domain.cpp
@@ -171,9 +171,29 @@ void domain_native::newdomain(name creator, const domain_name& name) {
     }
 }
 
+// TODO: std::map to ensure unique?
+void domain::declarenames(const std::vector<name_info>& domains) {
+    eosio_assert(domains.size(), "declarenames don't accept empty list");
+    std::vector<domain_name> prev;
+    for (const auto& info: domains) {
+        const auto& domain = info.domain;
+        const auto& dacc = info.account;
+        // TODO: it's handy to have domain name in assert messages
+        validate_domain_name(domain);
+        eosio_assert(std::find(prev.begin(), prev.end(), domain) == prev.end(), "same domain declared several times");
+        eosio_assert(is_domain(domain), "domain don't exists");
+        eosio_assert(dacc == resolve_domain(domain), "domain resolves to different account");
+        prev.push_back(domain);
+        for (const auto& u: info.users) {
+            validate_username(u);
+            eosio_assert(is_username(dacc, u), "username don't exists in domain");
+        }
+    }
+}
+
 } // eosiosystem
 
 
 EOSIO_DISPATCH(eosiosystem::domain,
-    (checkwin)(biddomain)(biddmrefund)(newdomain)
+    (newdomain)(checkwin)(biddomain)(biddmrefund)(declarenames)
 )

--- a/cyber.domain/cyber.domain.hpp
+++ b/cyber.domain/cyber.domain.hpp
@@ -16,6 +16,13 @@ using eosio::asset;
 using eosio::time_point_sec;
 
 
+// declares domain and linked account to ensure deferred tx applied for right account
+struct [[eosio::table, eosio::contract("cyber.domain")]] name_info {
+    domain_name domain;             // domain
+    name account;                   // account_name linked to given domain
+    std::vector<username> users;    // usernames of this domain used in tx
+};
+
 struct [[eosio::table, eosio::contract("cyber.domain")]] domain_bid {
     uint64_t        id;
     domain_name     domain;
@@ -63,6 +70,10 @@ public:
     [[eosio::action]] void checkwin();
     [[eosio::action]] void biddomain(name bidder, const domain_name& name, asset bid);
     [[eosio::action]] void biddmrefund(name bidder, const domain_name& name);
+
+    // Ensures that at execution time given domains linked to specified accounts and usernames exist.
+    // Also can be parsed by explorers to resolve account_names to full names.
+    [[eosio::action]] void declarenames(const std::vector<name_info>& domains);
 };
 
 } /// eosiosystem


### PR DESCRIPTION
Action accepts list of `name_info` structures. Each structure describes one domain: it's name, currently linked account and list of usernames of that domain. Action checks two things:
1. all items must exist at the moment when it applied
2. domain name currently linked to provided account

Cleos/libs should add this action to transaction if use domain names / usernames.
Explorers may parse this action to resolve account names to originally used domains/usernames.

Note: current implementation do not check, if all specified accounts actually exist in actions of transaction. It can be implemented, but the cost of such checks is high enough, because it will need read abi and deserialize actions. The absence of this check can lead transaction sender to add more info than enough to check, but he will need to pay for used bandwidth.

Note: current implementation have no info about positions of used domains/usernames. The transaction can contain action with e.g. 5 accounts as arguments, like `someaction(name a, name b, name c, name d, name e)`. If user sends something like `someaction(acc1, one@golos, two@golos, acc1, three@golos)` and it resolves to same account (`someaction(acc1,acc1,acc1,acc1,acc3)`) then `declarenames` will contain only what usernames/domains used, but not positions, in which they were used, like:
```
declarenames([{
    domain:"golos",
    account:N(acc1),
    users:["one","two","three"]
}])
```
