### PR TITLE
Add min_transaction_ram_usage to blockchain_parameters

### DIFF
--- a/cyber.bios/abi/cyber.bios.abi
+++ b/cyber.bios/abi/cyber.bios.abi
@@ -86,6 +86,10 @@
                     "type": "uint32"
                 },
                 {
+                    "name": "min_transaction_ram_usage",
+                    "type": "uint64"
+                },
+                {
                     "name": "max_transaction_lifetime",
                     "type": "uint32"
                 },

--- a/scripts/bios-boot-sequence/genesis.json
+++ b/scripts/bios-boot-sequence/genesis.json
@@ -13,6 +13,7 @@
     "target_block_cpu_usage_pct": 500,
     "max_transaction_cpu_usage": 1000000,
     "min_transaction_cpu_usage": 100,
+    "min_transaction_ram_usage": 1024,
     "max_transaction_lifetime": 3600,
     "deferred_trx_expiration_window": 600,
     "max_transaction_delay": 3888000,

--- a/tests/cyber.system_tester.hpp
+++ b/tests/cyber.system_tester.hpp
@@ -337,6 +337,7 @@ public:
          ("target_block_cpu_usage_pct", 10 + n )
          ("max_transaction_cpu_usage", 1000000 + n )
          ("min_transaction_cpu_usage", 100 + n )
+         ("min_transaction_ram_usage", 1024 + n )
          ("max_transaction_lifetime", 3600 + n)
          ("deferred_trx_expiration_window", 600 + n)
          ("max_transaction_delay", 10*86400+n)


### PR DESCRIPTION
The part of GolosChain/cyberway#629