### PR TITLE
Remove dependence from cyber.system #164

### DIFF
--- a/cyber.domain/CMakeLists.txt
+++ b/cyber.domain/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_contract_with_abi(cyber.domain cyber.domain.abi ${CMAKE_CURRENT_SOURCE_DIR}/cyber.domain.cpp)
 target_include_directories(cyber.domain.wasm
    PUBLIC
-   ${CMAKE_CURRENT_SOURCE_DIR}/../cyber.system/include
    ${CMAKE_CURRENT_SOURCE_DIR}/../cyber.token/include
    ${CMAKE_CURRENT_SOURCE_DIR}/..)
 

--- a/cyber.domain/cyber.domain.cpp
+++ b/cyber.domain/cyber.domain.cpp
@@ -1,6 +1,5 @@
 #include "cyber.domain.hpp"
 #include <common/config.hpp>
-#include <cyber.system/cyber.system.hpp>
 #include <cyber.token/cyber.token.hpp>
 #include <eosiolib/eosio.hpp>
 #include <eosiolib/transaction.hpp>
@@ -13,7 +12,7 @@ namespace eosiosystem {
 
 // constants
 const uint32_t seconds_per_hour      = 60 * 60;
-// const uint32_t seconds_per_day       = 24 * seconds_per_hour;    // declared in eosio::system header…
+const uint32_t seconds_per_day       = 24 * seconds_per_hour;
 const uint32_t seconds_per_year      = 365 * seconds_per_day;   // note: it's 52*7=364 in eos
 
 // config

--- a/cyber.govern/include/cyber.govern/cyber.govern.hpp
+++ b/cyber.govern/include/cyber.govern/cyber.govern.hpp
@@ -7,8 +7,8 @@ using eosio::name;
 using eosio::contract;
 using eosio::public_key;
 
-class [[contract("cyber.govern")]] govern : public contract {
-    
+class [[eosio::contract("cyber.govern")]] govern : public contract {
+
 struct structures {
     struct [[eosio::table("state")]] state_info {
         uint32_t block_num = 0;
@@ -35,12 +35,12 @@ struct structures {
 
     using state_singleton = eosio::singleton<"governstate"_n, structures::state_info>;
     using producers = eosio::multi_index<"producer"_n, structures::producer>;
-    
+
     struct change_of_participants {
         std::vector<name> hired;
         std::vector<name> fired;
     };
-    
+
     change_of_participants get_change_of_producers(producers& producers_table, std::vector<name> new_producers, bool active_only);
     void shrink_to_active_producers(producers& producers_table, std::vector<std::pair<name, public_key> >& arg);
     void update_and_reward_producers(producers& producers_table, structures::state_info& s);
@@ -48,10 +48,10 @@ struct structures {
     void sum_up(producers& producers_table);
     bool maybe_promote_active_producers(const structures::state_info& s);
     int64_t get_target_emission_per_block(int64_t supply) const;
-    
+
 public:
     using contract::contract;
-    
+
     [[eosio::action]] void onblock(name producer);
     [[eosio::action]] void setactprods(std::vector<name> pending_active_producers);
     [[eosio::action]] void setignored(std::vector<name> ignored_producers);

--- a/tests/cyber.token_tests.cpp
+++ b/tests/cyber.token_tests.cpp
@@ -1,7 +1,7 @@
 #include <boost/test/unit_test.hpp>
 #include <eosio/testing/tester.hpp>
 #include <eosio/chain/abi_serializer.hpp>
-#include "cyber.system_tester.hpp"
+#include "contracts.hpp"
 
 #include "Runtime/Runtime.h"
 

--- a/tests/golos_tester.cpp
+++ b/tests/golos_tester.cpp
@@ -155,10 +155,10 @@ vector<variant> golos_tester::get_all_chaindb_rows(name code, uint64_t scope, na
     return all;
 }
 
-void golos_tester::delegate_authority(account_name from, std::vector<account_name> to, 
+void golos_tester::delegate_authority(account_name from, std::vector<account_name> to,
         account_name code, action_name type, permission_name req,
         permission_name parent, permission_name prov) {
-            
+
     authority auth(1, {});
     for (auto u : to) {
         auth.accounts.emplace_back(permission_level_weight{.permission = {u, prov}, .weight = 1});

--- a/tests/golos_tester.hpp
+++ b/tests/golos_tester.hpp
@@ -49,11 +49,12 @@ protected:
     std::map<account_name, abi_serializer> _abis;
 
 public:
-    golos_tester(name code, bool push_genesis = true): tester(base_tester::default_config(), push_genesis), _code(code), _chaindb(control->chaindb()) {
-        std::cout << "golos_tester()" << std::endl;
+    golos_tester(name code, bool push_genesis = true)
+    : tester(base_tester::default_config("_GOLOSTEST_"), push_genesis)
+    , _code(code)
+    , _chaindb(control->chaindb()) {
     }
     ~golos_tester() {
-        std::cout << "~golos_tester()" << std::endl;
     }
 
     void install_contract(account_name acc, const std::vector<uint8_t>& wasm, const std::vector<char>& abi, bool produce = true, const private_key_type* signer = nullptr);

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -10,9 +10,7 @@
 #include <eosio/chain/exceptions.hpp>
 #include <Runtime/Runtime.h>
 
-#include "cyber.system_tester.hpp"
 
-using namespace cyber_system;
 #define BOOST_TEST_STATIC_LINK
 
 void translate_fc_exception(const fc::exception &e) {


### PR DESCRIPTION
also fixes cyber.govern warning and updates tester to use testing tables scope