### PR TITLE
Transaction header

### DIFF
--- a/cyber.msig/abi/cyber.msig.abi
+++ b/cyber.msig/abi/cyber.msig.abi
@@ -266,6 +266,14 @@
                     "type": "uint8"
                 },
                 {
+                    "name": "max_ram_kbytes",
+                    "type": "varuint32"
+                },
+                {
+                    "name": "max_storage_kbytes",
+                    "type": "varuint32"
+                },
+                {
                     "name": "delay_sec",
                     "type": "varuint32"
                 }

--- a/tests/cyber.msig_tests.cpp
+++ b/tests/cyber.msig_tests.cpp
@@ -144,6 +144,8 @@ transaction cyber_msig_tester::reqauth( account_name from, const vector<permissi
       ("ref_block_prefix", 3)
       ("max_net_usage_words", 0)
       ("max_cpu_usage_ms", 0)
+      ("max_ram_kbytes", 0)
+      ("max_storage_kbytes", 0)
       ("delay_sec", 0)
       ("actions", fc::variants({
             fc::mutable_variant_object()
@@ -310,6 +312,8 @@ BOOST_FIXTURE_TEST_CASE( big_transaction, cyber_msig_tester ) try {
       ("ref_block_prefix", 3)
       ("max_net_usage_words", 0)
       ("max_cpu_usage_ms", 0)
+      ("max_ram_kbytes", 0)
+      ("max_storage_kbytes", 0)
       ("delay_sec", 0)
       ("actions", fc::variants({
             fc::mutable_variant_object()

--- a/tests/cyber.stake_test_api.hpp
+++ b/tests/cyber.stake_test_api.hpp
@@ -9,39 +9,13 @@ namespace eosio { namespace testing {
 
 struct cyber_stake_api: base_contract_api {
     bool verbose;
-    uint32_t billed_cpu_time_us = 0;
-    uint64_t billed_ram_bytes = 0;
+    uint32_t billed_cpu_time_us = base_tester::DEFAULT_BILLED_CPU_TIME_US;
+    uint64_t billed_ram_bytes = base_tester::DEFAULT_BILLED_RAM_BYTES;
 public:
     cyber_stake_api(golos_tester* tester, name code, bool verbose_ = true)
     :   base_contract_api(tester, code), verbose(verbose_){}
     
     void set_verbose(bool verbose_) { verbose = verbose_; };
-    void set_billed(uint32_t cpu_time_us, uint64_t ram_bytes) {
-        billed_cpu_time_us = cpu_time_us;
-        billed_ram_bytes   = ram_bytes;
-    }
-
-    action_result push(action_name name, account_name signer, const variant_object& data) {
-        try {
-            signed_transaction trx;
-            vector<permission_level> auths;
-
-            auths.push_back( permission_level{signer, config::active_name} );
-
-            trx.actions.emplace_back( _tester->get_action( _code, name, auths, data ) );
-            _tester->set_transaction_headers( trx, _tester->DEFAULT_EXPIRATION_DELTA, 0 );
-            for (const auto& auth : auths) {
-                trx.sign( _tester->get_private_key( auth.actor, auth.permission.to_string() ), _tester->control->get_chain_id() );
-            }
-
-            _tester->push_transaction(trx, fc::time_point::maximum(), billed_cpu_time_us, billed_ram_bytes);
-
-        } catch (const fc::exception& ex) {
-            edump((ex.to_detail_string()));
-            return _tester->error(ex.top_message());
-        }
-        return _tester->success();
-    }
 
     ////actions
     action_result create(account_name issuer, symbol token_symbol,

--- a/tests/cyber.stake_tests.cpp
+++ b/tests/cyber.stake_tests.cpp
@@ -363,6 +363,7 @@ BOOST_FIXTURE_TEST_CASE(bw_tests, cyber_stake_tester) try {
     double ram_using_prop = 0.0001;
     double ram_capacity = config::default_min_virtual_limits[resource_limits::RAM] * config::default_account_usage_windows[resource_limits::RAM] / config::block_interval_ms;
     stake.set_billed(100, ram_capacity * ram_using_prop);
+    token.set_billed(100, ram_capacity * ram_using_prop);
 
     std::vector<uint8_t> max_proxies = {30, 10, 3, 1};
     int64_t frame_length = 30;
@@ -399,8 +400,18 @@ BOOST_FIXTURE_TEST_CASE(bw_tests, cyber_stake_tester) try {
     BOOST_CHECK_EQUAL(success(), stake.setproxylvl(_alice, token._symbol.to_symbol_code(), 2));
 
     produce_block();
+
+    for (int i = 0; i < 3; ++i) {
+        BOOST_CHECK_EQUAL(success(), stake.setproxylvl(_bob, token._symbol.to_symbol_code(), 2));
+        BOOST_CHECK_EQUAL(success(), stake.setproxylvl(_bob, token._symbol.to_symbol_code(), 1));
+        produce_block();
+    }
     BOOST_CHECK(err.is_insufficient_staked_mssg(stake.setproxylvl(_bob, token._symbol.to_symbol_code(), 2)));
-    stake.setproxylvl(_alice, token._symbol.to_symbol_code(), 3, false);
+    for (int i = 0; i < 4; ++i) {
+        BOOST_CHECK_EQUAL(success(), stake.setproxylvl(_alice, token._symbol.to_symbol_code(), 3, false));
+        BOOST_CHECK_EQUAL(success(), stake.setproxylvl(_alice, token._symbol.to_symbol_code(), 2, false));
+        produce_block();
+    }
     BOOST_CHECK(err.is_insufficient_staked_mssg(stake.setproxylvl(_alice, token._symbol.to_symbol_code(), 1)));
     produce_block();
     auto params = control->get_global_properties().configuration;


### PR DESCRIPTION
This PR is part of GolosChain/CyberWay#732
- Add upper limit on RAM and STORAGE to transaction header in cyber.msig
- Update cyber.stake tests after fix on STORAGE usage 