### PR TITLE
Increase memo for token methods to 384 symbols. #176

### DIFF
--- a/cyber.token/src/cyber.token.cpp
+++ b/cyber.token/src/cyber.token.cpp
@@ -201,6 +201,7 @@ void token::add_payment( name owner, asset value, name ram_payer )
 void token::open( name owner, const symbol& symbol, name ram_payer )
 {
    require_auth( ram_payer );
+   eosio_assert( is_account( owner ), "owner account does not exist");
 
    auto sym_code_raw = symbol.code().raw();
 

--- a/cyber.token/src/cyber.token.cpp
+++ b/cyber.token/src/cyber.token.cpp
@@ -9,6 +9,11 @@
 
 namespace eosio {
 
+namespace config {
+    static constexpr size_t max_memo_size = 384;
+    static constexpr char memo_error[] = "memo has more than 384 bytes";
+}
+
 void token::send_currency_event(const currency_stats& stat) {
     eosio::event(_self, "currency"_n, stat).send();
 }
@@ -46,7 +51,7 @@ void token::issue( name to, asset quantity, string memo )
 {
     auto sym = quantity.symbol;
     eosio_assert( sym.is_valid(), "invalid symbol name" );
-    eosio_assert( memo.size() <= 256, "memo has more than 256 bytes" );
+    eosio_assert( memo.size() <= config::max_memo_size, config::memo_error );
 
     stats statstable( _self, sym.code().raw() );
     auto existing = statstable.find( sym.code().raw() );
@@ -78,7 +83,7 @@ void token::retire( asset quantity, string memo )
 {
     auto sym = quantity.symbol;
     eosio_assert( sym.is_valid(), "invalid symbol name" );
-    eosio_assert( memo.size() <= 256, "memo has more than 256 bytes" );
+    eosio_assert( memo.size() <= config::max_memo_size, config::memo_error );
 
     stats statstable( _self, sym.code().raw() );
     auto existing = statstable.find( sym.code().raw() );
@@ -134,7 +139,7 @@ void token::do_transfer( name  from,
     eosio_assert( quantity.is_valid(), "invalid quantity" );
     eosio_assert( quantity.amount > 0, "must transfer positive quantity" );
     eosio_assert( quantity.symbol == st.supply.symbol, "symbol precision mismatch" );
-    eosio_assert( memo.size() <= 256, "memo has more than 256 bytes" );
+    eosio_assert( memo.size() <= config::max_memo_size, config::memo_error );
 
     auto payer = has_auth( to ) ? to : from;
 

--- a/tests/cyber.stake_tests.cpp
+++ b/tests/cyber.stake_tests.cpp
@@ -397,21 +397,8 @@ BOOST_FIXTURE_TEST_CASE(bw_tests, cyber_stake_tester) try {
     
     BOOST_CHECK_EQUAL(success(), stake.reward(_issuer, _carol, reward_c));
     BOOST_CHECK_EQUAL(success(), token.transfer(_issuer, _code, stake_w, "whale"));
-    BOOST_CHECK_EQUAL(success(), stake.setproxylvl(_alice, token._symbol.to_symbol_code(), 2));
-
-    for (int i = 0; i < 3; ++i) {
-        produce_block();
-        BOOST_CHECK_EQUAL(success(), stake.setproxylvl(_bob, token._symbol.to_symbol_code(), 2));
-        BOOST_CHECK_EQUAL(success(), stake.setproxylvl(_bob, token._symbol.to_symbol_code(), 1));
-    }
-    produce_block();
+    BOOST_CHECK(err.is_insufficient_staked_mssg(stake.setproxylvl(_alice, token._symbol.to_symbol_code(), 2)));
     BOOST_CHECK(err.is_insufficient_staked_mssg(stake.setproxylvl(_bob, token._symbol.to_symbol_code(), 3)));
-    for (int i = 0; i < 4; ++i) {
-        BOOST_CHECK_EQUAL(success(), stake.setproxylvl(_alice, token._symbol.to_symbol_code(), 3, false));
-        BOOST_CHECK_EQUAL(success(), stake.setproxylvl(_alice, token._symbol.to_symbol_code(), 2, false));
-        produce_block();
-    }
-    BOOST_CHECK(err.is_insufficient_staked_mssg(stake.setproxylvl(_alice, token._symbol.to_symbol_code(), 1)));
     produce_block();
     auto params = control->get_global_properties().configuration;
     auto prev_min_ram = params.min_virtual_limits[resource_limits::RAM];

--- a/tests/cyber.token_tests.cpp
+++ b/tests/cyber.token_tests.cpp
@@ -525,6 +525,7 @@ BOOST_FIXTURE_TEST_CASE( open_tests, cyber_token_tester ) try {
    auto bob_balance = get_account(N(bob), "0,CERO");
    BOOST_REQUIRE_EQUAL(true, bob_balance.is_null() );
 
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg( "owner account does not exist" ), open( N(bobdilan), "0,CERO", N(alice) ) );
    BOOST_REQUIRE_EQUAL( success(), open( N(bob), "0,CERO", N(alice) ) );
 
    bob_balance = get_account(N(bob), "0,CERO");


### PR DESCRIPTION
Resolve #176: Increase memo size for token methods to 384 symbols.
Resolve #166: Add checking of exists account on token open. 

Additional:
Fixes for cyber.stake after GolosChain/cyberway#793