### PR TITLE
Improve domain auction #188

### DIFF
--- a/cyber.domain/cyber.domain.abi
+++ b/cyber.domain/cyber.domain.abi
@@ -61,7 +61,9 @@
         },{
             "name": "checkwin",
             "base": "",
-            "fields": []
+            "fields": [
+                {"type": "name",        "name": "checker"}
+            ]
         },{
             "name": "declarenames",
             "base": "",
@@ -81,8 +83,7 @@
             "base": "",
             "fields": [
                 {"type": "uint64",         "name": "id"},
-                {"type": "time_point_sec", "name": "last_win"},
-                {"type": "time_point_sec", "name": "last_checkwin"}
+                {"type": "time_point_sec", "name": "last_win"}
             ]
         },{
             "name": "domain_bid",

--- a/cyber.domain/cyber.domain.hpp
+++ b/cyber.domain/cyber.domain.hpp
@@ -50,10 +50,9 @@ using domain_bid_refund_tbl = eosio::multi_index< "dbidrefund"_n, domain_bid_ref
 
 struct [[eosio::table("state"), eosio::contract("cyber.domain")]] domain_bid_state {
     time_point_sec last_win;
-    time_point_sec last_checkwin;
 
     // explicit serialization macro is not necessary, used here only to improve compilation time
-    EOSLIB_SERIALIZE(domain_bid_state, (last_win)(last_checkwin))
+    EOSLIB_SERIALIZE(domain_bid_state, (last_win))
 };
 using state_singleton = eosio::singleton<"dbidstate"_n, domain_bid_state>;
 
@@ -67,7 +66,7 @@ public:
 
     using domain_native::domain_native;
 
-    [[eosio::action]] void checkwin();
+    [[eosio::action]] void checkwin(name checker);
     [[eosio::action]] void biddomain(name bidder, const domain_name& name, asset bid);
     [[eosio::action]] void biddmrefund(name bidder, const domain_name& name);
 


### PR DESCRIPTION
Resolves #188 

Now checkwin not delaying. It can be executed by anyone,
Field `last_checkwin`, which was used for delaying, is removed.