### PR TITLE
Creating subaccounts by prefix instead of suffix #201

### DIFF
--- a/cyber.bios/src/cyber.bios.cpp
+++ b/cyber.bios/src/cyber.bios.cpp
@@ -56,18 +56,18 @@ void bios::checkwin() {
 
 // TODO: can be added to CDT
 name get_prefix(name acc) {
-  auto tmp = acc.value;
-  auto remain_bits = 64;
-  for (; remain_bits >= -1; remain_bits-=5) {
-    if ((tmp >> 59) == 0) { // 1st symbol is dot
-      break;
+    auto tmp = acc.value;
+    auto remain_bits = 64;
+    for (; remain_bits >= -1; remain_bits-=5) {
+        if ((tmp >> 59) == 0) { // 1st symbol is dot
+            break;
+        }
+        tmp <<= 5;
     }
-    tmp <<= 5;
-  }
-  if (remain_bits == -1) {
-    remain_bits = 0;
-  }
-  return name{acc.value >> remain_bits << remain_bits};
+    if (remain_bits == -1) {
+        remain_bits = 0;
+    }
+    return name{acc.value >> remain_bits << remain_bits};
 }
 
 void bios::bidname( name bidder, name newname, eosio::asset bid ) {
@@ -78,6 +78,7 @@ void bios::bidname( name bidder, name newname, eosio::asset bid ) {
 
    eosio::check( (bool)newname, "the empty name is not a valid account name to bid on" );
    eosio::check( (newname.value & 0xFull) == 0, "13 character names are not valid account names to bid on" );
+   eosio::check( (newname.value & 0x1F0ull) == 0, "accounts with 12 character names can be created without bidding required" );
    eosio::check( !is_account( newname ), "account already exists" );
    eosio::check( bid.symbol == core_symbol(), "asset must be system token" );
    eosio::check( bid.amount > 0, "insufficient bid" );
@@ -138,15 +139,17 @@ void bios::bidrefund( name bidder ) {
 
 void bios::newaccount(name creator, name newact, ignore<authority> owner, ignore<authority> active) {
     if( creator != _self ) {
-        auto prefix = get_prefix(newact);
-        if (prefix == newact) {
-            name_bid_table bids(_self, _self.value);
-            auto current = bids.require_find( newact.value, "no active bid for name" );
-            eosio::check( current->high_bidder == creator, "only highest bidder can claim" );
-            eosio::check( current->high_bid < 0, "auction for name is not closed yet" );
-            bids.erase( current );
-        } else {
-            eosio::check( creator == prefix, "only prefix may create this account" );
+        if ((newact.value & 0x1F0ull) == 0) { // Name is less than 12 characters
+            auto prefix = get_prefix(newact);
+            if (prefix == newact) {
+                name_bid_table bids(_self, _self.value);
+                auto current = bids.require_find( newact.value, "no active bid for name" );
+                eosio::check( current->high_bidder == creator, "only highest bidder can claim" );
+                eosio::check( current->high_bid < 0, "auction for name is not closed yet" );
+                bids.erase( current );
+            } else {
+                eosio::check( creator == prefix, "only prefix may create this account" );
+            }
         }
     }
 }

--- a/tests/cyber.bios_tests.cpp
+++ b/tests/cyber.bios_tests.cpp
@@ -234,6 +234,12 @@ BOOST_FIXTURE_TEST_CASE( bid_invalid_names, cyber_bios_tester ) try {
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "13 character names are not valid account names to bid on" ),
                         bidname( N(dan), N(abcdefgh12345), token.from_amount(1) ) );
 
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg( "accounts with 12 character names can be created without bidding required" ),
+                        bidname( N(dan), N(abcdefg12345), token.from_amount(1) ) );
+
+   BOOST_TEST_MESSAGE("Testing creating 12-character account without bidding");
+
+   create_accounts_with_resources({ N(abcdefg12345) }, N(dan));
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( multiple_namebids, cyber_bios_tester ) try {

--- a/tests/cyber.bios_tests.cpp
+++ b/tests/cyber.bios_tests.cpp
@@ -234,12 +234,18 @@ BOOST_FIXTURE_TEST_CASE( bid_invalid_names, cyber_bios_tester ) try {
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "13 character names are not valid account names to bid on" ),
                         bidname( N(dan), N(abcdefgh12345), token.from_amount(1) ) );
 
-   BOOST_REQUIRE_EQUAL( wasm_assert_msg( "accounts with 12 character names can be created without bidding required" ),
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg( "accounts with 12 character names without dots can be created without bidding required" ),
                         bidname( N(dan), N(abcdefg12345), token.from_amount(1) ) );
 
    BOOST_TEST_MESSAGE("Testing creating 12-character account without bidding");
 
    create_accounts_with_resources({ N(abcdefg12345) }, N(dan));
+
+   BOOST_TEST_MESSAGE("Testing creating 12-character account with dot without bidding (failure)");
+
+   BOOST_REQUIRE_EXCEPTION(create_accounts_with_resources({ N(abcde.g12345) }, N(dan)),
+                            eosio_assert_message_exception, eosio_assert_message_is( "only prefix may create this account" ) );
+
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( multiple_namebids, cyber_bios_tester ) try {


### PR DESCRIPTION
Resolves #201 

Removes ability of free creating accounts without dots, because it will allow create prefix for free.