### PR TITLE
 Add Buildkite CI scripts #211

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,9 @@
+steps:
+  - label: ":docker: build docker image"
+    command: ".buildkite/steps/build-image.sh"
+
+  - wait
+
+  - label: ":cop::skin-tone-2: deploy check"
+    command: ".buildkite/steps/deploy-test.sh"
+    timeout: 20

--- a/.buildkite/steps/build-image.sh
+++ b/.buildkite/steps/build-image.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGETAG=${BUILDKITE_BRANCH:-master}
+BRANCHNAME=${BUILDKITE_BRANCH:-master}
+
+if [[ "${IMAGETAG}" == "alfa" ]]; then
+    BUILDTYPE="alfa"
+else
+    BUILDTYPE="latest"
+fi
+
+cd Docker
+docker build -t cyberway/cyberway.contracts:${IMAGETAG} --build-arg branch=${BRANCHNAME} --build-arg buildtype=${BUILDTYPE} .

--- a/.buildkite/steps/deploy-test.sh
+++ b/.buildkite/steps/deploy-test.sh
@@ -1,0 +1,21 @@
+#/bin/bash
+
+set -euo pipefail
+
+docker volume rm cyberway-mongodb-data || true
+docker volume create --name=cyberway-mongodb-data
+
+cd Docker
+
+IMAGETAG=${BUILDKITE_BRANCH:-master}
+
+docker-compose up -d
+
+# Run unit-tests
+sleep 10s
+docker run --network cyberway-tests_contracts-net -ti cyberway/cyberway.contracts:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway.contracts/unit_test -l message -r detailed'
+result=$?
+
+docker-compose down
+
+exit $result

--- a/.buildkite/steps/deploy-test.sh
+++ b/.buildkite/steps/deploy-test.sh
@@ -2,10 +2,11 @@
 
 set -euo pipefail
 
-docker volume rm cyberway-mongodb-data || true
-docker volume create --name=cyberway-mongodb-data
-
 cd Docker
+
+docker-compose down
+docker volume rm cyberway-system-mongodb-data || true
+docker volume create --name=cyberway-system-mongodb-data
 
 IMAGETAG=${BUILDKITE_BRANCH:-master}
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,45 @@
+ARG buildtype=stable
+FROM cyberway/cyberway:$buildtype as cyberway
+FROM cyberway/cyberway.cdt:$buildtype as cdt
+
+FROM cyberway/builder:$buildtype as builder
+COPY --from=cdt /opt/cyberway.cdt /opt/cyberway.cdt
+COPY --from=cyberway /opt/cyberway /opt/cyberway
+
+ARG branch=master
+ADD https://api.github.com/repos/GolosChain/cyberway.contracts/git/refs/heads/$branch /etc/version.json
+RUN git clone -b $branch https://github.com/GolosChain/cyberway.contracts.git --recursive
+
+RUN cd cyberway.contracts \
+    && echo "$branch:$(git rev-parse HEAD)" > version \
+    && cmake -H. -B"build" \
+        -GNinja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/opt/cyberway.contracts/ \
+        -Deosio.cdt_DIR=/opt/cyberway.cdt/lib/cmake/eosio.cdt \
+        -DEOSIO_ROOT=/opt/cyberway \
+    && cmake --build build --target install
+
+
+FROM ubuntu:18.04
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates python3 python3-numpy python3-bson libusb-1.0-0-dev libcurl4-gnutls-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /cyberway.contracts/version /opt/cyberway.contracts/version
+COPY --from=builder /opt/cyberway.contracts/ /opt/cyberway.contracts/
+COPY --from=builder /cyberway.contracts/build/tests/unit_test /opt/cyberway.contracts/unit_test
+COPY --from=builder /cyberway.contracts/tests/test_contracts /opt/cyberway.contracts/test_contracts
+
+COPY --from=builder /cyberway.contracts/scripts/bios-boot-sequence /opt/cyberway.contracts/scripts/bios-boot-sequence
+
+COPY --from=builder /usr/local/lib/libbson-1.0.so.0.0.0 /usr/local/lib/
+COPY --from=cyberway /opt/cyberway/bin/cleos /opt/cyberway/bin/cleos
+COPY --from=cyberway /opt/cyberway/bin/keosd /opt/cyberway/bin/keosd
+COPY --from=cyberway /opt/cyberway/bin/create-genesis /opt/cyberway/bin/create-genesis
+
+RUN ldconfig && ln -s ../cyberway.contracts /opt/cyberway.contracts
+
+ENV CYBERWAY_TEST_CONTRACTS /opt/cyberway.contracts/test_contracts/
+ENV CYBERWAY_CONTRACTS /opt/cyberway.contracts/

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -1,0 +1,25 @@
+
+version: "2.1"
+
+services:
+  mongo:
+    container_name: mongo
+    image: mongo
+    restart: always
+    healthcheck:
+       test: mongo --eval 'db.getCollectionNames()'
+       interval: 2s
+       timeout: 2s
+       retries: 10
+    volumes:
+      - cyberway-mongodb-data:/data/db
+    ports:
+      - 127.0.0.1:27018:27017
+
+volumes:
+ cyberway-mongodb-data:
+   external: true
+
+networks:
+    default:
+       name: cyberway-tests_contracts-net

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -12,12 +12,12 @@ services:
        timeout: 2s
        retries: 10
     volumes:
-      - cyberway-mongodb-data:/data/db
+      - cyberway-system-mongodb-data:/data/db
     ports:
       - 127.0.0.1:27018:27017
 
 volumes:
- cyberway-mongodb-data:
+ cyberway-system-mongodb-data:
    external: true
 
 networks:


### PR DESCRIPTION
Resolve #211:
- Creates `cyberway/cyberway.contracts:${BRANCHNAME}` image - builds and runs tests, but not uploading it to Dockerhub because we using for this repo another mechanism - submodules.
- Uses `cyberway:alfa` and `cyberway.cdt:alfa` if branch is https://github.com/GolosChain/cyberway.contracts/tree/alfa, and uses `:latest` with any other branch including https://github.com/GolosChain/cyberway.contracts/tree/master.